### PR TITLE
Cluster deployment form

### DIFF
--- a/frontend/packages/acm-plugin/src/components/clusters.tsx
+++ b/frontend/packages/acm-plugin/src/components/clusters.tsx
@@ -17,6 +17,7 @@ import { ClusterKind, ClusterStatusKind } from '../types';
 import { getLabelValue, getClusterStatus, getLoadedData } from '../selectors';
 import { ClusterStatus } from './cluster-status';
 import { ClusterNodes } from './cluster-nodes';
+import { getCreateClusterDropdownProps } from './create-cluster/utils';
 
 const tableColumnClasses = [
   classNames('col-lg-3', 'col-md-3', 'col-sm-4', 'col-xs-4'),
@@ -152,11 +153,14 @@ export const ClustersPage: React.FC<ClustersPageProps> = (props) => {
   return (
     <MultiListPage
       {...props}
-      namespace={undefined}
+      createProps={getCreateClusterDropdownProps()}
+      createButtonText="Deploy or Import Cluster"
+      namespace={undefined /* TODO: remove? */}
       ListComponent={ClusterList}
       title="Advanced Clusters Management"
       resources={resources}
       flatten={flatten}
+      canCreate
     />
   );
 };

--- a/frontend/packages/acm-plugin/src/components/create-cluster/CreateCluster.tsx
+++ b/frontend/packages/acm-plugin/src/components/create-cluster/CreateCluster.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react';
+import * as Yup from 'yup';
+import * as _ from 'lodash';
+import { Formik } from 'formik';
+import { history, resourcePathFromModel, FirehoseResult } from '@console/internal/components/utils';
+import { nameValidationSchema } from '@console/dev-console/src/components/import/validation-schema';
+import { getName } from '@console/shared/src';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import {
+  createClusterDeployment,
+  updateClusterDeployment,
+} from '../../k8s/requests/cluster-deployment';
+import { getLoadedData } from '@console/shared/src/utils';
+import { usePrevious } from '@console/shared/src/hooks';
+import CreateClusterForm from './CreateClusterForm';
+import { CreateClusterFormValues } from '../../types/cluster-deployment';
+import { ClusterDeploymentModel } from '../../models';
+import {
+  getPlatformLabel,
+  getBaseDomain,
+  getPullSecret,
+  getSSHPrivateKey,
+  getInstallConfigFromSecret,
+  getApiVIP,
+  getDnsVIP,
+  getIngressVIP,
+  getMachineCIDR,
+  getLibvirtURI,
+  getSSHPublicKey,
+} from '../../selectors/cluster-deployment';
+// import { MAC_REGEX, BMC_ADDRESS_REGEX } from './utils';
+
+const getInitialValues = (
+  clusterDeployment: K8sResourceKind,
+  pullSecret: K8sResourceKind,
+  sshPrivateKeySecret: K8sResourceKind,
+  installConfigSecret: K8sResourceKind,
+): CreateClusterFormValues => {
+  const installConfig = getInstallConfigFromSecret(installConfigSecret);
+  return {
+    clusterName: getName(clusterDeployment) || '',
+    platform: getPlatformLabel(clusterDeployment) || 'bareMetal',
+    baseDomain: getBaseDomain(clusterDeployment) || '',
+    pullSecret: getPullSecret(pullSecret) || '',
+    sshPrivateKey: getSSHPrivateKey(sshPrivateKeySecret) || '',
+    sshPublicKey: getSSHPublicKey(installConfig) || '',
+    libvirtURI: getLibvirtURI(installConfig) || '',
+    apiVIP: getApiVIP(installConfig) || '',
+    dnsVIP: getDnsVIP(installConfig) || '',
+    ingressVIP: getIngressVIP(installConfig) || '',
+    machineCIDR: getMachineCIDR(installConfig) || '',
+  };
+};
+
+type CreateClusterProps = {
+  namespace: string;
+  isEditing: boolean;
+  loaded?: boolean;
+  clusterDeployments?: FirehoseResult<K8sResourceKind[]>;
+  clusterDeployment?: FirehoseResult<K8sResourceKind>;
+  pullSecret?: FirehoseResult<K8sResourceKind>;
+  sshPrivateKeySecret?: FirehoseResult<K8sResourceKind>;
+  machinePool?: FirehoseResult<K8sResourceKind>;
+  installConfigSecret?: FirehoseResult<K8sResourceKind>;
+  installManifestsConfigMap?: FirehoseResult<K8sResourceKind>;
+};
+
+const CreateCluster: React.FC<CreateClusterProps> = ({
+  namespace,
+  isEditing,
+  clusterDeployments,
+  clusterDeployment: clusterDeploymentResult,
+  pullSecret: pullSecretResult,
+  sshPrivateKeySecret: sshPrivateKeyResult,
+  machinePool: machinePoolResult,
+  installConfigSecret: installConfigResult,
+  installManifestsConfigMap: installManifestsResult,
+}) => {
+  const [reload, setReload] = React.useState<boolean>(false);
+  const clusterDeploymentNames = _.flatMap(getLoadedData(clusterDeployments, []), (cd) =>
+    getName(cd),
+  );
+  const clusterDeployment = getLoadedData(clusterDeploymentResult);
+  const prevClusterDeployment = usePrevious(clusterDeployment);
+
+  const pullSecret = getLoadedData(pullSecretResult);
+  const prevPullSecret = usePrevious(pullSecret);
+
+  const sshPrivateKeySecret = getLoadedData(sshPrivateKeyResult);
+  const prevSshPrivateKeySecret = usePrevious(sshPrivateKeySecret);
+
+  const installConfigSecret = getLoadedData(installConfigResult);
+  const prevInstallConfigSecret = usePrevious(installConfigSecret);
+
+  // TODO(jtomasek): remove these if it is not needed to track/update for editting
+  const machinePool = getLoadedData(machinePoolResult);
+  const installManifestsConfigMap = getLoadedData(installManifestsResult);
+
+  const initialValues = getInitialValues(
+    clusterDeployment,
+    pullSecret,
+    sshPrivateKeySecret,
+    installConfigSecret,
+  );
+  const prevInitialValues = getInitialValues(
+    prevClusterDeployment,
+    prevPullSecret,
+    prevSshPrivateKeySecret,
+    prevInstallConfigSecret,
+  );
+
+  React.useEffect(() => {
+    if (reload) {
+      setReload(false);
+    }
+  }, [reload, setReload]);
+
+  const showUpdated =
+    isEditing && prevClusterDeployment && !_.isEqual(prevInitialValues, initialValues);
+
+  const validationSchema = Yup.object().shape({
+    clusterName: Yup.mixed()
+      .test(
+        'unique-name',
+        'Cluster name "${value}" is already taken.', // eslint-disable-line no-template-curly-in-string
+        (value) => !clusterDeploymentNames.includes(value),
+      )
+      .concat(nameValidationSchema),
+  });
+
+  const handleSubmit = (values, actions) => {
+    const params = { ...values, namespace };
+    const promise = isEditing
+      ? updateClusterDeployment(clusterDeployment, pullSecret, sshPrivateKeySecret, params)
+      : createClusterDeployment(params);
+
+    promise
+      .then(() => {
+        actions.setSubmitting(false);
+        history.push(resourcePathFromModel(ClusterDeploymentModel, values.name, namespace));
+      })
+      .catch((error) => {
+        actions.setSubmitting(false);
+        actions.setStatus({ submitError: error.message });
+      });
+  };
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      enableReinitialize={isEditing && (reload || !prevClusterDeployment)}
+      onSubmit={handleSubmit}
+      onReset={() => setReload(true)}
+      validationSchema={validationSchema}
+    >
+      {(props) => <CreateClusterForm {...props} isEditing={isEditing} showUpdated={showUpdated} />}
+    </Formik>
+  );
+};
+
+export default CreateCluster;

--- a/frontend/packages/acm-plugin/src/components/create-cluster/CreateClusterForm.tsx
+++ b/frontend/packages/acm-plugin/src/components/create-cluster/CreateClusterForm.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { history } from '@console/internal/components/utils';
+import { FormikProps } from 'formik';
+import { Form, TextInputTypes } from '@patternfly/react-core';
+import { InputField, FormFooter, DropdownField, TextAreaField } from '@console/shared/src';
+import { CreateClusterFormValues } from '../../types/cluster-deployment';
+
+type CreateClusterFormProps = FormikProps<CreateClusterFormValues> & {
+  isEditing: boolean;
+  showUpdated: boolean;
+};
+
+const CreateClusterForm: React.FC<CreateClusterFormProps> = ({
+  errors,
+  handleSubmit,
+  handleReset,
+  status,
+  isSubmitting,
+  dirty,
+  isEditing,
+  showUpdated,
+}) => (
+  <Form onSubmit={handleSubmit}>
+    <InputField
+      type={TextInputTypes.text}
+      data-test-id="deploy-cluster-form-cluster-name-input"
+      name="clusterName"
+      label="Cluster Name"
+      placeholder="mycluster"
+      helpText="Provide unique name for the new Cluster."
+      required
+      isDisabled={isEditing}
+    />
+    <InputField
+      type={TextInputTypes.text}
+      data-test-id="deploy-cluster-form-base-domain-input"
+      name="baseDomain"
+      label="Base DNS Domain"
+      placeholder="base.domain"
+      helpText="Provide unique name for the new Cluster."
+      required
+      isDisabled={isEditing}
+    />
+    <DropdownField
+      data-test-id="deploy-cluster-form-platform-dropdown"
+      name="platform"
+      label="Infrastructure Platform"
+      items={{
+        bareMetal: 'Bare Metal',
+        aws: 'Amazon Web Services',
+      }}
+      required
+      disabled
+    />
+    <TextAreaField
+      data-test-id="deploy-cluster-form-pull-secret-textarea"
+      name="pullSecret"
+      label="Pull Secret"
+      required
+    />
+    <TextAreaField
+      data-test-id="deploy-cluster-form-ssh-private-key-textarea"
+      name="sshPrivateKey"
+      label="SSH Private Key"
+      required
+    />
+    <TextAreaField
+      data-test-id="deploy-cluster-form-ssh-public-key-textarea"
+      name="sshPublicKey"
+      label="SSH Public Key"
+      required
+    />
+    <InputField
+      type={TextInputTypes.text}
+      data-test-id="deploy-cluster-form-libvirt-uri-input"
+      name="libvirtURI"
+      label="Libvirt URI"
+      placeholder=""
+      required
+    />
+    <InputField
+      type={TextInputTypes.text}
+      data-test-id="deploy-cluster-form-api-vip-input"
+      name="apiVIP"
+      label="API Virtual IP"
+      placeholder=""
+      required
+    />
+    <InputField
+      type={TextInputTypes.text}
+      data-test-id="deploy-cluster-form-dns-vip-input"
+      name="dnsVIP"
+      label="Internal DNS Virtual IP"
+      placeholder=""
+      required
+    />
+    <InputField
+      type={TextInputTypes.text}
+      data-test-id="deploy-cluster-form-ingress-vip-input"
+      name="ingressVIP"
+      label="Ingress Virtual IP"
+      placeholder=""
+      required
+    />
+    <InputField
+      type={TextInputTypes.text}
+      data-test-id="deploy-cluster-form-machine-cidr-input"
+      name="machineCIDR"
+      label="Machine CIDR"
+      placeholder=""
+      required
+    />
+    <FormFooter
+      isSubmitting={isSubmitting}
+      handleReset={showUpdated && handleReset}
+      handleCancel={history.goBack}
+      submitLabel={isEditing ? 'Save' : 'Create'}
+      errorMessage={status && status.submitError}
+      disableSubmit={isSubmitting || !dirty || !_.isEmpty(errors)}
+      infoTitle={'Resources have been updated'}
+      infoMessage={'Click reload to see the recent changes'}
+      showAlert={showUpdated}
+    />
+  </Form>
+);
+
+export default CreateClusterForm;

--- a/frontend/packages/acm-plugin/src/components/create-cluster/CreateClusterPage.tsx
+++ b/frontend/packages/acm-plugin/src/components/create-cluster/CreateClusterPage.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
+import { Firehose, FirehoseResource } from '@console/internal/components/utils';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { SecretModel, ConfigMapModel } from '@console/internal/models';
+import { ClusterDeploymentModel, MachinePoolModel } from '../../models';
+import CreateCluster from './CreateCluster';
+import {
+  getPullSecretName,
+  getSSHPrivateKeyName,
+  getMachinePoolName,
+  getInstallManifestsName,
+  getInstallConfigName,
+} from '../../k8s/objects/cluster-deployment';
+
+export type CreateClusterPageProps = RouteComponentProps<{ ns?: string; name?: string }>;
+
+const CreateClusterPage: React.FC<CreateClusterPageProps> = ({ match }) => {
+  const { name, ns: namespace } = match.params;
+  const resources: FirehoseResource[] = [];
+
+  const isEditing = !!name;
+  if (isEditing) {
+    resources.push(
+      {
+        kind: referenceForModel(ClusterDeploymentModel),
+        namespaced: true,
+        namespace: name,
+        name,
+        isList: false,
+        prop: 'clusterDeployment',
+      },
+      {
+        kind: referenceForModel(SecretModel),
+        namespaced: true,
+        namespace: name,
+        name: getPullSecretName(name),
+        isList: false,
+        prop: 'pullSecret',
+      },
+      {
+        kind: referenceForModel(SecretModel),
+        namespaced: true,
+        namespace: name,
+        name: getSSHPrivateKeyName(name),
+        isList: false,
+        prop: 'sshPrivateKeySecret',
+      },
+      {
+        kind: referenceForModel(SecretModel),
+        namespaced: true,
+        namespace: name,
+        name: getInstallConfigName(name),
+        isList: false,
+        prop: 'installConfigSecret',
+      },
+      {
+        kind: referenceForModel(MachinePoolModel),
+        namespaced: true,
+        namespace: name,
+        name: getMachinePoolName(name),
+        isList: false,
+        prop: 'machinePool',
+      },
+      {
+        kind: referenceForModel(ConfigMapModel),
+        namespaced: true,
+        namespace: name,
+        name: getInstallManifestsName(name),
+        isList: false,
+        prop: 'installManifestsConfigMap',
+      },
+      // load associated secrets as well (install-config etc.)
+      // {
+      //   kind: SecretModel.kind,
+      //   namespaced: true,
+      //   namespace,
+      //   name: getInstallConfigSecretName(name),
+      //   isList: false,
+      //   prop: 'secret',
+      // },
+    );
+  }
+  resources.push({
+    kind: referenceForModel(ClusterDeploymentModel),
+    namespaced: true,
+    namespace,
+    isList: true,
+    prop: 'clusterDeployments',
+  });
+
+  const title = 'Deploy a cluster';
+  return (
+    <>
+      <Helmet>
+        <title>{title}</title>
+      </Helmet>
+      <div className="co-m-pane__body co-m-pane__form">
+        {/* TODO(jtomasek): Turn this to PageHeading alternative for create forms (e.g.
+        CreateResourceFormPageHeading) */}
+        <h1 className="co-m-pane__heading co-m-pane__heading--baseline">
+          <div className="co-m-pane__name">{title}</div>
+        </h1>
+        <Firehose resources={resources}>
+          <CreateCluster namespace={namespace} isEditing={isEditing} />
+        </Firehose>
+      </div>
+    </>
+  );
+};
+
+export default CreateClusterPage;

--- a/frontend/packages/acm-plugin/src/components/create-cluster/utils.ts
+++ b/frontend/packages/acm-plugin/src/components/create-cluster/utils.ts
@@ -1,0 +1,27 @@
+import { ClusterModel, ClusterDeploymentModel } from '../../models';
+
+export const getCreateClusterDropdownProps = () => {
+  const items: any = {
+    deployDialog: 'Deploy cluster via dialog',
+    deployYaml: 'Deploy cluster from YAML',
+    importDialog: 'Import existing cluster',
+  };
+
+  return {
+    items,
+    createLink: (itemName) => {
+      const base = `/${ClusterDeploymentModel.plural}`;
+      const importBase = `/${ClusterModel.plural}`;
+
+      switch (itemName) {
+        case 'deployDialog':
+          return `${base}/~new/form`;
+        case 'importDialog':
+          return `${importBase}/~new/import`;
+        case 'deployYaml':
+        default:
+          return `${base}/~new`;
+      }
+    },
+  };
+};

--- a/frontend/packages/acm-plugin/src/k8s/objects/cluster-deployment.ts
+++ b/frontend/packages/acm-plugin/src/k8s/objects/cluster-deployment.ts
@@ -1,0 +1,246 @@
+import { safeDump } from 'js-yaml';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { ClusterDeploymentModel, MachinePoolModel } from '../../models';
+import { SecretModel, ConfigMapModel } from '@console/internal/models';
+import { ClusterDeploymentParams } from '../../types/cluster-deployment';
+
+const platformLabelToObject = (label) => ({ [label]: {} });
+
+export const getPullSecretName = (clusterName: string): string => `${clusterName}-pull-secret`;
+export const getInstallConfigName = (clusterName: string): string =>
+  `${clusterName}-install-config`;
+export const getSSHPrivateKeyName = (clusterName: string): string =>
+  `${clusterName}-ssh-private-key`;
+export const getInstallManifestsName = (clusterName: string): string =>
+  `${clusterName}-install-manifests`;
+export const getMachinePoolName = (clusterName: string): string => `${clusterName}-worker`;
+
+export const buildClusterDeploymentObject = ({
+  clusterName,
+  platform,
+  baseDomain,
+}: ClusterDeploymentParams): K8sResourceKind => ({
+  apiVersion: `${ClusterDeploymentModel.apiGroup}/${ClusterDeploymentModel.apiVersion}`,
+  kind: ClusterDeploymentModel.kind,
+  metadata: {
+    name: clusterName,
+    namespace: clusterName,
+    annotations: {
+      'hive.openshift.io/try-install-once': 'true',
+    },
+  },
+  spec: {
+    baseDomain,
+    clusterName,
+    controlPlaneConfig: {},
+    images: {
+      installerImagePullPolicy: 'Always',
+    },
+    installed: false,
+    platform: platformLabelToObject(platform),
+    provisioning: {
+      releaseImage:
+        'quay.io/openshift-release-dev/ocp-release@sha256:ea7ac3ad42169b39fce07e5e53403a028644810bee9a212e7456074894df40f3',
+      installConfigSecretRef: {
+        name: getInstallConfigName(clusterName),
+      },
+      sshPrivateKeySecretRef: {
+        name: getSSHPrivateKeyName(clusterName),
+      },
+      manifestsConfigMapRef: {
+        name: getInstallManifestsName(clusterName),
+      },
+      sshKnownHosts: [],
+    },
+    pullSecretRef: {
+      name: getPullSecretName(clusterName),
+    },
+  },
+});
+
+export const buildPullSecretObject = ({
+  clusterName,
+  pullSecret,
+}: ClusterDeploymentParams): K8sResourceKind => ({
+  apiVersion: SecretModel.apiVersion,
+  kind: SecretModel.kind,
+  metadata: {
+    name: getPullSecretName(clusterName),
+    namespace: clusterName,
+  },
+  stringData: {
+    '.dockerconfigjson': pullSecret,
+  },
+  type: 'kubernetes.io/dockerconfigjson',
+});
+
+export const buildSshPrivateKeyObject = ({
+  clusterName,
+  sshPrivateKey,
+}: ClusterDeploymentParams): K8sResourceKind => ({
+  apiVersion: SecretModel.apiVersion,
+  kind: SecretModel.kind,
+  metadata: {
+    name: getSSHPrivateKeyName(clusterName),
+    namespace: clusterName,
+  },
+  stringData: {
+    'ssh-privatekey': sshPrivateKey,
+  },
+  type: 'Opaque',
+});
+
+export const buildInstallConfigObject = ({
+  clusterName,
+  baseDomain,
+  platform,
+  sshPublicKey,
+  pullSecret,
+  libvirtURI,
+  apiVIP,
+  dnsVIP,
+  ingressVIP,
+  machineCIDR,
+}: ClusterDeploymentParams): any => ({
+  apiVersion: 'v1',
+  baseDomain,
+  networking: {
+    machineCIDR,
+  },
+  metadata: {
+    name: clusterName,
+  },
+  compute: [
+    {
+      name: 'worker',
+      replicas: 0,
+    },
+  ],
+  controlPlane: {
+    name: 'master',
+    replicas: 3,
+    platform: platformLabelToObject(platform),
+  },
+  platform: {
+    baremetal: {
+      libvirtURI,
+      dnsVIP,
+      apiVIP,
+      ingressVIP,
+      provisioningBridge: 'provisioning',
+      externalBridge: 'baremetal',
+      hosts: [
+        {
+          name: 'openshift-master-0',
+          role: 'master',
+          bmc: {
+            address: 'ipmi://192.168.111.1:6230',
+            username: 'admin',
+            password: 'password',
+          },
+          bootMACAddress: '00:6e:f1:e7:1e:83',
+          hardwareProfile: 'default',
+        },
+        {
+          name: 'openshift-master-1',
+          role: 'master',
+          bmc: {
+            address: 'ipmi://192.168.111.1:6231',
+            username: 'admin',
+            password: 'password',
+          },
+          bootMACAddress: '00:6e:f1:e7:1e:87',
+          hardwareProfile: 'default',
+        },
+        {
+          name: 'openshift-master-2',
+          role: 'master',
+          bmc: {
+            address: 'ipmi://192.168.111.1:6232',
+            username: 'admin',
+            password: 'password',
+          },
+          bootMACAddress: '00:6e:f1:e7:1e:8b',
+          hardwareProfile: 'default',
+        },
+      ],
+    },
+  },
+  pullSecret,
+  sshKey: sshPublicKey,
+});
+
+export const buildInstallConfigSecretObject = (
+  params: ClusterDeploymentParams,
+): K8sResourceKind => {
+  const { clusterName } = params;
+  return {
+    apiVersion: SecretModel.apiVersion,
+    kind: SecretModel.kind,
+    metadata: {
+      name: getInstallConfigName(clusterName),
+      namespace: clusterName,
+    },
+    data: {
+      'install-config.yaml': btoa(safeDump(buildInstallConfigObject(params))),
+    },
+    type: 'Opaque',
+  };
+};
+
+export const metal3ConfigConfigMap: K8sResourceKind = {
+  apiVersion: ConfigMapModel.apiVersion,
+  kind: ConfigMapModel.kind,
+  metadata: {
+    name: 'metal3-config',
+    namespace: 'openshift-machine-api',
+  },
+  data: {
+    cache_url: '',
+    deploy_kernel_url: 'http://172.22.0.3:6180/images/ironic-python-agent.kernel',
+    deploy_ramdisk_url: 'http://172.22.0.3:6180/images/ironic-python-agent.initramfs',
+    dhcp_range: '172.22.0.10,172.22.0.100',
+    http_port: '6180',
+    ironic_endpoint: 'http://172.22.0.3:6385/v1/',
+    ironic_inspector_endpoint: 'http://172.22.0.3:5050/v1/',
+    provisioning_interface: 'eno1',
+    provisioning_ip: '172.22.0.3/24',
+    rhcos_image_url:
+      'https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.3/43.81.201911221453.0/x86_64/rhcos-43.81.201911221453.0-openstack.x86_64.qcow2.gz',
+  },
+};
+
+export const buildInstallManifestsConfigMapObject = ({
+  clusterName,
+}: ClusterDeploymentParams): K8sResourceKind => ({
+  apiVersion: ConfigMapModel.apiVersion,
+  kind: ConfigMapModel.kind,
+  metadata: {
+    creationTimestamp: null,
+    name: getInstallManifestsName(clusterName),
+    namespace: clusterName,
+  },
+  data: {
+    'metal3-config.yaml': safeDump(metal3ConfigConfigMap),
+  },
+});
+
+export const buildMachinePoolObject = ({
+  clusterName,
+  platform,
+}: ClusterDeploymentParams): K8sResourceKind => ({
+  apiVersion: `${MachinePoolModel.apiGroup}/${MachinePoolModel.apiVersion}`,
+  kind: MachinePoolModel.kind,
+  metadata: {
+    name: getMachinePoolName(clusterName),
+    namespace: clusterName,
+  },
+  spec: {
+    clusterDeploymentRef: {
+      name: clusterName,
+    },
+    name: 'worker',
+    platform: platformLabelToObject(platform),
+    replicas: 0,
+  },
+});

--- a/frontend/packages/acm-plugin/src/k8s/requests/cluster-deployment.ts
+++ b/frontend/packages/acm-plugin/src/k8s/requests/cluster-deployment.ts
@@ -1,0 +1,60 @@
+import { safeDump } from 'js-yaml';
+import {
+  buildClusterDeploymentObject,
+  buildPullSecretObject,
+  buildSshPrivateKeyObject,
+  buildMachinePoolObject,
+  buildInstallManifestsConfigMapObject,
+  buildInstallConfigSecretObject,
+} from '../objects/cluster-deployment';
+// import { PatchBuilder } from '@console/shared/src/k8s/patch';
+import { k8sCreate, k8sPatch, K8sResourceKind } from '@console/internal/module/k8s';
+import { ClusterDeploymentModel, MachinePoolModel } from '../../models';
+import { ClusterDeploymentParams } from '../../types/cluster-deployment';
+import { SecretModel, ConfigMapModel } from '@console/internal/models';
+
+export const createClusterDeployment = async (params: ClusterDeploymentParams) => {
+  const clusterDeployment = buildClusterDeploymentObject(params);
+  const pullSecret = buildPullSecretObject(params);
+  const sshPrivateKeySecret = buildSshPrivateKeyObject(params);
+  const machinePool = buildMachinePoolObject(params);
+  const installManifestsConfigMap = buildInstallManifestsConfigMapObject(params);
+  const installConfigSecret = buildInstallConfigSecretObject(params);
+  console.log('ClusterDeployment: \n', safeDump(clusterDeployment));
+  console.log('Pull Secret: \n', safeDump(pullSecret));
+  console.log('SSH Private Key: \n', safeDump(sshPrivateKeySecret));
+  console.log('Machine Pool: \n', safeDump(machinePool));
+  console.log('Install Manifests: \n', safeDump(installManifestsConfigMap));
+  console.log('Install Config: \n', safeDump(installConfigSecret));
+  // await k8sCreate(SecretModel, pullSecret);
+  // await k8sCreate(SecretModel, sshPrivateKeySecret);
+  // await k8sCreate(SecretModel, installConfigSecret);
+  // await k8sCreate(ConfigMapModel, installManifestsConfigMap);
+  // await k8sCreate(ClusterDeploymentModel, clusterDeployment);
+  // await k8sCreate(MachinePoolModel, machinePool);
+};
+
+export const updateClusterDeployment = async (
+  clusterDeployment: K8sResourceKind,
+  pullSecret: K8sResourceKind,
+  sshPrivateKeySecret: K8sResourceKind,
+  {
+    clusterName,
+    namespace,
+    baseDomain,
+    platform,
+    pullSecret,
+    sshPrivateKey,
+  }: ClusterDeploymentParams,
+) => {
+  const patches = [
+    // ...new PatchBuilder('/spec').buildAddObjectKeysPatches(
+    //   { description },
+    //   clusterDeployment.spec,
+    // ),
+  ];
+
+  if (patches.length > 0) {
+    await k8sPatch(ClusterDeploymentModel, clusterDeployment, patches);
+  }
+};

--- a/frontend/packages/acm-plugin/src/models/index.ts
+++ b/frontend/packages/acm-plugin/src/models/index.ts
@@ -56,3 +56,29 @@ export const PolicyModel: K8sKind = {
   plural: 'policies',
   id: '',
 };
+
+export const ClusterDeploymentModel: K8sKind = {
+  kind: 'ClusterDeployment',
+  label: 'ClusterDeployment',
+  labelPlural: 'ClusterDeployments',
+  apiGroup: 'hive.openshift.io',
+  apiVersion: 'v1',
+  abbr: 'CD',
+  namespaced: true,
+  crd: true,
+  plural: 'clusterdeployments',
+  id: 'clusterdeployment',
+};
+
+export const MachinePoolModel: K8sKind = {
+  kind: 'MachinePool',
+  label: 'MachinePool',
+  labelPlural: 'MachinePools',
+  apiGroup: 'hive.openshift.io',
+  apiVersion: 'v1',
+  abbr: 'MP',
+  namespaced: true,
+  crd: true,
+  plural: 'machinepools',
+  id: 'machinepool',
+};

--- a/frontend/packages/acm-plugin/src/plugin.tsx
+++ b/frontend/packages/acm-plugin/src/plugin.tsx
@@ -107,6 +107,18 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: `/${models.ClusterDeploymentModel.plural}/~new/form`,
+      loader: () =>
+        import('./components/create-cluster/CreateClusterPage' /* webpackChunkName: "mcm" */).then(
+          (m) => m.default,
+        ),
+      required: FLAG_ACM,
+    },
+  },
+  {
     type: 'Page/Resource/Details',
     properties: {
       model: models.ClusterModel,

--- a/frontend/packages/acm-plugin/src/selectors/cluster-deployment.ts
+++ b/frontend/packages/acm-plugin/src/selectors/cluster-deployment.ts
@@ -1,0 +1,40 @@
+import { safeLoad } from 'js-yaml';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { ClusterDeploymentPlatform } from '../types/cluster-deployment';
+
+export const getPlatform = (clusterDeployment: K8sResourceKind): ClusterDeploymentPlatform =>
+  clusterDeployment?.spec?.platform;
+
+export const getPlatformLabel = (clusterDeployment: K8sResourceKind): string => {
+  const platform = getPlatform(clusterDeployment);
+  return platform ? Object.keys(getPlatform(clusterDeployment))[0] : '';
+};
+
+export const getBaseDomain = (clusterDeployment: K8sResourceKind): string =>
+  clusterDeployment?.spec?.baseDomain;
+
+export const getPullSecret = (secret: K8sResourceKind): string =>
+  secret?.stringData?.['.dockerconfigjson'];
+
+export const getSSHPrivateKey = (secret: K8sResourceKind): string =>
+  secret?.stringData?.['ssh-privatekey'];
+
+export const getInstallConfigFromSecret = (secret: K8sResourceKind) => {
+  const installConfigEncoded = secret?.data?.['install-config.yaml'];
+  return installConfigEncoded && safeLoad(atob(secret?.data?.['install-config.yaml']));
+};
+
+export const getLibvirtURI = (installConfig: any): string =>
+  installConfig?.platform?.baremetal?.libvirtURI;
+
+export const getApiVIP = (installConfig: any): string => installConfig?.platform?.baremetal?.apiVIP;
+
+export const getDnsVIP = (installConfig: any): string => installConfig?.platform?.baremetal?.dnsVIP;
+
+export const getIngressVIP = (installConfig: any): string =>
+  installConfig?.platform?.baremetal?.ingressVIP;
+
+export const getMachineCIDR = (installConfig: any): string =>
+  installConfig?.platform?.baremetal?.machineCIDR;
+
+export const getSSHPublicKey = (installConfig: any): string => installConfig?.sshKey;

--- a/frontend/packages/acm-plugin/src/types/cluster-deployment.ts
+++ b/frontend/packages/acm-plugin/src/types/cluster-deployment.ts
@@ -1,0 +1,21 @@
+export type ClusterDeploymentPlatform = {
+  [key: string]: any;
+};
+
+export type CreateClusterFormValues = {
+  clusterName: string;
+  platform: string;
+  baseDomain: string;
+  pullSecret: string;
+  sshPrivateKey: string;
+  sshPublicKey: string;
+  libvirtURI: string;
+  apiVIP: string;
+  dnsVIP: string;
+  ingressVIP: string;
+  machineCIDR: string;
+};
+
+export type ClusterDeploymentParams = CreateClusterFormValues & {
+  namespace: string;
+};

--- a/frontend/packages/console-shared/src/hooks.ts
+++ b/frontend/packages/console-shared/src/hooks.ts
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from 'react';
+
+export const usePrevious = (value) => {
+  const ref = useRef();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};

--- a/frontend/packages/console-shared/src/utils/utils.ts
+++ b/frontend/packages/console-shared/src/utils/utils.ts
@@ -26,3 +26,8 @@ export const createLookup = <A extends K8sResourceKind>(
   }
   return {};
 };
+
+export const getLoadedData = (
+  result: FirehoseResult<K8sResourceKind | K8sResourceKind[]>,
+  defaultValue = null,
+) => (result && result.loaded && !result.loadError ? result.data : defaultValue);

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -120,8 +120,9 @@ export type K8sResourceKind = K8sResourceCommon & {
     [key: string]: any;
   };
   status?: { [key: string]: any };
-  type?: { [key: string]: any };
+  type?: string | { [key: string]: any };
   data?: { [key: string]: any };
+  stringData?: { [key: string]: string };
 };
 
 export type VolumeMount = {


### PR DESCRIPTION
Introduces a form to generate all necessary resources for deploying the cluster.
The form is also ready to cover cluster deployment editting

TODO:
- finish updateClusterDeployment function with required patches
- Add BareMetalAssets listing to enable selecting hosts for deployment,
  this should eventually populate the installConfig with references
  to BMAssets, for now it should just add the hosts to installConfig
  More on multicluster inventory controller here:
  https://github.com/mhrivnak/multicluster-inventory/pull/11/files
- Add validations for all fields including hosts selection restrictions
- Add fields and update resources to use remote hypervisor connection
- Turn the form into a wizard (sections: General, Platform, Security,
  Hosts, Network)
- Add cluster deployment editting + status/progress tracking and
  integrate it into clusters listing and cluster detail
- Define new types for resources used for cluster deployment - SecretKind,
  InstallConfig type, ClusterDeploymentKind